### PR TITLE
Fill empty descriptions headers to avoid invalid ifc

### DIFF
--- a/Examples/Alignment/Examples/Sectioned Solid/File.ifc
+++ b/Examples/Alignment/Examples/Sectioned Solid/File.ifc
@@ -1,6 +1,6 @@
 ﻿ISO-10303-21;
 HEADER;
-FILE_DESCRIPTION($,'2;1');
+FILE_DESCRIPTION((''),'2;1');
 FILE_NAME('IfcSectionedSolidHorizontal-Optimized.ifc','2016-12-05T01:41:56',(''),(''),'Constructivity 2016.12.05','Constructivity 2016.12.05','');
 FILE_SCHEMA(('IFC4X1'));
 ENDSEC;

--- a/Examples/Building element standard case/Examples/Element standard case/File.ifc
+++ b/Examples/Building element standard case/Examples/Element standard case/File.ifc
@@ -1,6 +1,6 @@
 ﻿ISO-10303-21;
 HEADER;
-FILE_DESCRIPTION($,'2;1');
+FILE_DESCRIPTION((''),'2;1');
 FILE_NAME('StandardCase.ifc','2014-09-17T20:56:49',(''),(''),'Constructivity 0.9.8.1','Constructivity 0.9.8.1','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;

--- a/Examples/Building service element/Examples/Air terminal element/File.ifc
+++ b/Examples/Building service element/Examples/Air terminal element/File.ifc
@@ -1,6 +1,6 @@
 ﻿ISO-10303-21;
 HEADER;
-FILE_DESCRIPTION($,'2;1');
+FILE_DESCRIPTION((''),'2;1');
 FILE_NAME('building_service_element_air-terminal.ifc','2011-11-11T23:58:37',(''),(''),'Constructivity 0.9.1','Constructivity 0.9.1','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;

--- a/Examples/Building service element/Examples/Air terminal library object/File.ifc
+++ b/Examples/Building service element/Examples/Air terminal library object/File.ifc
@@ -1,6 +1,6 @@
 ﻿ISO-10303-21;
 HEADER;
-FILE_DESCRIPTION($,'2;1');
+FILE_DESCRIPTION((''),'2;1');
 FILE_NAME('building_service_element_air-terminal-type.ifc','2011-11-11T21:50:39',(''),(''),'Constructivity 0.9.1','Constructivity 0.9.1','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;

--- a/Examples/Structural analysis model/Examples/Structural curve member/File.ifc
+++ b/Examples/Structural analysis model/Examples/Structural curve member/File.ifc
@@ -1,6 +1,6 @@
 ﻿ISO-10303-21;
 HEADER;
-FILE_DESCRIPTION($,'2;1');
+FILE_DESCRIPTION((''),'2;1');
 FILE_NAME('IfcStructuralCurveMember01.ifc','2011-11-07T14:57:06',(''),(''),'Constructivity 0.9.1','Constructivity 0.9.1','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;

--- a/Examples/Tessellated shape with style/Examples/Tessellation with blob texture/File.ifc
+++ b/Examples/Tessellated shape with style/Examples/Tessellation with blob texture/File.ifc
@@ -1,6 +1,6 @@
 ﻿ISO-10303-21;
 HEADER;
-FILE_DESCRIPTION($,'2;1');
+FILE_DESCRIPTION((''),'2;1');
 FILE_NAME('Tessellation-Texture-Blob.ifc','2016-05-06T03:48:25',(''),(''),'Constructivity 2016.02.09','Constructivity 2016.02.09','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;

--- a/Examples/Tessellated shape with style/Examples/Tessellation with image texture/File.ifc
+++ b/Examples/Tessellated shape with style/Examples/Tessellation with image texture/File.ifc
@@ -1,6 +1,6 @@
 ﻿ISO-10303-21;
 HEADER;
-FILE_DESCRIPTION($,'2;1');
+FILE_DESCRIPTION((''),'2;1');
 FILE_NAME('Tessellation-Texture-Image.ifc','2016-05-06T03:47:49',(''),(''),'Constructivity 2016.02.09','Constructivity 2016.02.09','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;

--- a/Examples/Tessellated shape with style/Examples/Tessellation with pixel texture/File.ifc
+++ b/Examples/Tessellated shape with style/Examples/Tessellation with pixel texture/File.ifc
@@ -1,6 +1,6 @@
 ﻿ISO-10303-21;
 HEADER;
-FILE_DESCRIPTION($,'2;1');
+FILE_DESCRIPTION((''),'2;1');
 FILE_NAME('Tessellation-Texture-Pixel.ifc','2016-05-06T03:48:56',(''),(''),'Constructivity 2016.02.09','Constructivity 2016.02.09','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;


### PR DESCRIPTION
Fixes the same issue as in https://github.com/buildingSMART/IFC4.3.x-sample-models/issues/11